### PR TITLE
Fixed bug making tags required

### DIFF
--- a/client/src/app/add-blog/add-blog.component.ts
+++ b/client/src/app/add-blog/add-blog.component.ts
@@ -42,7 +42,7 @@ export class AddBlogComponent implements OnInit {
         author:['', Validators.required],
         image:[''],
         body:['', Validators.required],
-        tags:['']
+        tags:[[]]
       })
     }
     
@@ -59,7 +59,7 @@ export class AddBlogComponent implements OnInit {
       if(tag.startsWith('#')){
         tag = tag.substring(1);
       }
-      if(!this.tags.includes(tag)){
+      if(!this.tags.includes(tag) && tag !== ''){
         this.tags.push(tag);
       }
       this.tagInput.nativeElement.value = "";


### PR DESCRIPTION
1. Reference Related Issue: #
Fixes a bug causing issue #64 

2. Describe the changes proposed in this pull request:
Changes the initial value of tags in reactiveForm in add-blog-component to be an empty array instead of an empty string. Also prevents an empty string from being added as a tag.

3. @rrolon47 and @jwoolbright23 to review proposed changes.
